### PR TITLE
Add WinRT API Back into PowerShell Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+publish.ps1

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -351,4 +351,7 @@ function Read-Package {
         $bootstrapper.ReadNuspec( $Package )
     }
 }
+If( ($bootstrapper.Runtime -match "^win") -and ($bootstrapper.System.Framework -eq ".NETCoreApp") ){
+    Import-Package Microsoft.Windows.SDK.NET.Ref # Automatically fixes the missing WinRT functionality in PowerShell Core on Windows
+}
 Export-ModuleMember -Cmdlet Import-Package, Read-Package, Get-Dotnet -Function Import-Package, Read-Package, Get-Dotnet

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ PowerShell is an amazing language, but doesn't get all the love that C# does by 
 ## Features
 - Adds ability to import NuGet/Nupkg packages downloaded by PackageManagement
   - `Import-Package`
+  - For PowerShell Core on Windows, adds WinRT API back into PowerShell Core on Windows
+    - This will add UWP APIs back into PowerShell Core on Windows
+    - Uses this workaround: https://github.com/PowerShell/PowerShell/issues/13042#issuecomment-653357546
 - (WIP) Adds significantly improved asynchronous code execution by providing runspace constructors that return a dispatcher
   - `New-DispatcherSpace`
-- (WIP) For PowerShell Core on Windows, adds WinRT API back into PowerShell Core on Windows
-  - This will add UWP APIs back into PowerShell Core on Windows
-  - Will use this workaround: https://github.com/PowerShell/PowerShell/issues/13042#issuecomment-653357546


### PR DESCRIPTION
Automatically implements this fix for PowerShell Core on Windows: https://github.com/PowerShell/PowerShell/issues/13042#issuecomment-653357546

This may have to be moved from the Import-Package module into a separate space later. For now, Import-Package is the only packaged module this repository has released.