### PR TITLE
Smallfix v0.0.6

### DIFF
--- a/Import-Package/Import-Package.psd1
+++ b/Import-Package/Import-Package.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Import-Package.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.5'
+ModuleVersion = '0.0.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Import-Package/packaging.ps1
+++ b/Import-Package/packaging.ps1
@@ -217,7 +217,6 @@ public static extern IntPtr dlopen(string path, int flags);
                                 $lib_handle
                             }
                         })
-                        -Force
                     
                     $this | Add-Member `
                         -MemberType ScriptMethod `


### PR DESCRIPTION
Fix typo that breaks `$bootstrapper.TestNative()`