### PR TITLE
Patch: 0.3.2 - Fix dependency group bug

### DIFF
--- a/Import-Package/Import-Package.psd1
+++ b/Import-Package/Import-Package.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Import-Package.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.1'
+ModuleVersion = '0.3.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Test.ps1
+++ b/Test.ps1
@@ -24,6 +24,10 @@ If( $ImportPackage ){
     Import-Package Avalonia.Desktop -Offline
     # Import-Package Avalonia.Win32 -Offline]
 
+    # --- Microsoft.ClearScript ---
+
+    Import-Package Microsoft.ClearScript -Offline
+
     Write-Host
     Write-Host (Get-Runtime)
 


### PR DESCRIPTION
This was found when trying to load Microsoft.ClearScript, since it does not have any dependency groups.