### PR TITLE
Patch: 0.4.1 - Add Support for Framework-Agnostic (OS-Agnostic Only) Files

### DIFF
--- a/Import-Package/Import-Package.psd1
+++ b/Import-Package/Import-Package.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Import-Package.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.0'
+ModuleVersion = '0.4.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Adds support for lib\*.dll files.
Does not add support for runtime\*\lib\*.dll files - This may be added in the future, but not at this time.