### PR TITLE
Patch: 0.4.2 - Fixes to support IronRuby import

### DIFF
--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -285,7 +285,7 @@ function Import-Package {
         Write-Verbose "[Import-Package:Framework-Handling] Selected OS-agnostic framework $TargetFramework"
         Write-Verbose "[Import-Package:Framework-Handling] Selected OS-specific framework $target_rid_framework"
 
-        If( $PackageData.Dependencies ){
+        If( $PackageData.Dependencies -and -not $Offline ){
             Write-Verbose "[Import-Package:Dependency-Handling] Loading dependencies for $( $PackageData.Name )"
             If( $PackageData.Dependencies.Agnostic ){
                 $package_framework = $TargetFramework

--- a/Import-Package/src/Build-PackageData.ps1
+++ b/Import-Package/src/Build-PackageData.ps1
@@ -135,10 +135,7 @@ function Build-PackageData {
             # Copy the nupkg to the temporary directory as well
             Copy-Item -Path $Options.Source.ToString() -Destination $Options.TempPath.ToString() -Force
 
-            $Out.Source = @(
-                $Options.TempPath.ToString(),
-                (Split-Path $Options.Source -Leaf)
-            ) -join "\"
+            $Out.Source = Join-Path $Options.TempPath.ToString() (Split-Path $Options.Source -Leaf)
         }
     }
 


### PR DESCRIPTION
* Don't automatically load dependencies when `-Offline`. Users can still manually load dependencies beforehand. Allows modules to be loaded completely offline
* Remove a hardcoded file path separator in `Build-PackageData`. There are others, but this is the only one that caused errors for me