### PR TITLE
Features: 0.5.0 - Add caching of -Path packages and add support for SemVer2 packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 publish.ps1
 *.dll
+Import-Package/Packages
+Import-Package/Temp

--- a/Import-Package/Import-Package.psd1
+++ b/Import-Package/Import-Package.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Import-Package.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.4'
+ModuleVersion = '0.5.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -6,6 +6,9 @@ $loaded = @{
 }
 $mutexes = @{}
 
+New-Item (Join-Path $PSScriptRoot "Packages") -Force -ItemType Directory
+New-Item (Join-Path $PSScriptRoot "Temp") -Force -ItemType Directory
+
 & {
     # Clear the Cache
     Write-Verbose "[Import-Package:Init] Clearing Temp Files..."
@@ -174,11 +177,10 @@ function Import-Package {
         [string] $Path,
         
         [switch] $Offline,
-        # [string] $CachePath = "$PSScriptRoot\Packages"
+        [string] $CachePath = "$PSScriptRoot\Packages",
         [string] $TempPath = (& {
             $parent = & {
-                [System.IO.Path]::GetTempPath()
-                # Join-Path ($CachePath | Split-Path -Parent) "Temp"
+                Join-Path ($CachePath | Split-Path -Parent) "Temp"
             }
             [string] $uuid = [System.Guid]::NewGuid()
 
@@ -212,6 +214,7 @@ function Import-Package {
                 Write-Verbose "[Import-Package:ParameterSet] Managed Object"
 
                 Build-PackageData -From "Object" -Options @( $Package, @{
+                    "CachePath" = $CachePath
                     "TempPath" = $TempPath
                 }) -Bootstrapper $bootstrapper
             }
@@ -219,6 +222,7 @@ function Import-Package {
                 Write-Verbose "[Import-Package:ParameterSet] Managed"
 
                 Build-PackageData -From "Install" -Options @{
+                    "CachePath" = $CachePath
                     "TempPath" = $TempPath
 
                     "Offline" = $Offline # If true, do not install
@@ -231,6 +235,7 @@ function Import-Package {
                 Write-Verbose "[Import-Package:ParameterSet] Unmanaged"
 
                 Build-PackageData -From "File" -Options @{
+                    "CachePath" = $CachePath
                     "TempPath" = $TempPath
 
                     "Source" = $Path

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -24,6 +24,7 @@ New-Item (Join-Path $PSScriptRoot "Temp") -Force -ItemType Directory
 }
 
 
+. "$PSScriptRoot\src\ConvertTo-SemVerObject.ps1"
 . "$PSScriptRoot\src\Resolve-DependencyVersions.ps1"
 . "$PSScriptRoot\src\Resolve-CachedPackage.ps1"
 . "$PSScriptRoot\src\Build-PackageData.ps1"

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -202,7 +202,7 @@ function Import-Package {
                         $compressed = $chars[$remainder] + $compressed
                         $bigint = $bigint/36
                     }
-                    Write-Verbose "[Import-Package:Directories] UUID $uuid (base16) converted to $compressed (base$( $chars.Length ))"
+                    Write-Verbose "[Import-Package:Preparation] UUID $uuid (base16) converted to $compressed (base$( $chars.Length ))"
     
                     $compressed
                 }

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -178,37 +178,45 @@ function Import-Package {
         
         [switch] $Offline,
         [string] $CachePath = "$PSScriptRoot\Packages",
-        [string] $TempPath = (& {
-            $parent = & {
-                Join-Path ($CachePath | Split-Path -Parent) "Temp"
-            }
-            [string] $uuid = [System.Guid]::NewGuid()
-
-            # Cut dirname in half by compressing the UUID from base16 (hexadecimal) to base36 (alphanumeric)
-            $id = & {
-                $bigint = [uint128]::Parse( $uuid.ToString().Replace("-",""), 'AllowHexSpecifier')
-                $compressed = ""
-                
-                # Make hex-string more compressed by encoding it in base36 (alphanumeric)
-                $chars = "0123456789abcdefghijklmnopqrstuvwxyz"
-                While( $bigint -gt 0 ){
-                    $remainder = $bigint % 36
-                    $compressed = $chars[$remainder] + $compressed
-                    $bigint = $bigint/36
-                }
-                Write-Verbose "[Import-Package:Directories] UUID $uuid (base16) converted to $compressed (base$( $chars.Length ))"
-
-                $compressed
-            }
-
-            $mutexes."$id" = New-Object System.Threading.Mutex($true, "Global\ImportPackage-$id") # Lock the directory from automatic removal
-
-            New-Item -ItemType Directory -Path (Join-Path $parent $id) -Force
-            # Resolve-Path "."
-        })
+        [string] $TempPath
     )
 
     Process {
+
+        $temp_path_generated = If( [string]::IsNullOrWhiteSpace( $TempPath ) ){
+            $TempPath = & {
+                $parent = & {
+                    Join-Path ($CachePath | Split-Path -Parent) "Temp"
+                }
+                [string] $uuid = [System.Guid]::NewGuid()
+    
+                # Cut dirname in half by compressing the UUID from base16 (hexadecimal) to base36 (alphanumeric)
+                $id = & {
+                    $bigint = [uint128]::Parse( $uuid.ToString().Replace("-",""), 'AllowHexSpecifier')
+                    $compressed = ""
+                    
+                    # Make hex-string more compressed by encoding it in base36 (alphanumeric)
+                    $chars = "0123456789abcdefghijklmnopqrstuvwxyz"
+                    While( $bigint -gt 0 ){
+                        $remainder = $bigint % 36
+                        $compressed = $chars[$remainder] + $compressed
+                        $bigint = $bigint/36
+                    }
+                    Write-Verbose "[Import-Package:Directories] UUID $uuid (base16) converted to $compressed (base$( $chars.Length ))"
+    
+                    $compressed
+                }
+    
+                $mutexes."$id" = New-Object System.Threading.Mutex($true, "Global\ImportPackage-$id") # Lock the directory from automatic removal
+    
+                New-Item -ItemType Directory -Path (Join-Path $parent $id) -Force
+                # Resolve-Path "."
+            }
+            $true
+        } Else {
+            $false
+        }
+
         $PackageData = Switch( $PSCmdlet.ParameterSetName ){
             "Managed-Object" {
                 Write-Verbose "[Import-Package:ParameterSet] Managed Object"
@@ -338,9 +346,9 @@ function Import-Package {
                     } Else {
                         Write-Verbose "[Import-Package:Dependency-Handling] ($($PackageData.Name) Dependency) Loading $($_.Name) - $($_.Version) (Framework $( $package_framework.GetShortFolderName() ))"
                         If( $PackageData.Offline ){
-                            Import-Package $_.Name -Version $_.Version -TargetFramework $package_framework -Offline
+                            Import-Package $_.Name -Version $_.Version -TargetFramework $package_framework -TempPath $PackageData.TempPath -Offline
                         } Else {
-                            Import-Package $_.Name -Version $_.Version -TargetFramework $package_framework
+                            Import-Package $_.Name -Version $_.Version -TargetFramework $package_framework -TempPath $PackageData.TempPath
                         }
                         Write-Verbose "[Import-Package:Dependency-Handling] ($($PackageData.Name) Dependency) $($_.Name) Loaded"
                     }
@@ -362,9 +370,9 @@ function Import-Package {
                     } Else {
                         Write-Verbose "[Import-Package:Dependency-Handling] ($($PackageData.Name) Dependency) Loading $($_.Name) - $($_.Version) (Framework $( ([NuGet.Frameworks.NuGetFramework]$package_framework).GetShortFolderName() ))"
                         If( $PackageData.Offline ){
-                            Import-Package $_.Name -Version $_.Version -TargetFramework $package_framework -Offline
+                            Import-Package $_.Name -Version $_.Version -TargetFramework $package_framework -TempPath $PackageData.TempPath -Offline
                         } Else {
-                            Import-Package $_.Name -Version $_.Version -TargetFramework $package_framework
+                            Import-Package $_.Name -Version $_.Version -TargetFramework $package_framework -TempPath $PackageData.TempPath
                         }
                         Write-Verbose "[Import-Package:Dependency-Handling] ($($PackageData.Name) Dependency) $($_.Name) Loaded"
                     }
@@ -488,10 +496,12 @@ function Import-Package {
             Write-Warning "[Import-Package:Loading] $($PackageData.Name) is not needed for $( $bootstrapper.Runtime )`:$($TargetFramework.GetShortFolderName())"
         }
 
-        If( Test-Path (Join-Path $TempPath "*") ){
-            Write-Verbose "[Import-Package:Loading] Temp files: $TempPath"
-        } Else {
-            Remove-Item -Path $TempPath -ErrorAction Stop
+        If( $temp_path_generated ){
+            If( Test-Path (Join-Path $TempPath "*") ){
+                Write-Verbose "[Import-Package:Loading] Temp files: $TempPath"
+            } Else {
+                Remove-Item -Path $TempPath -ErrorAction Stop
+            }
         }
     }
 }

--- a/Import-Package/packaging.ps1
+++ b/Import-Package/packaging.ps1
@@ -38,7 +38,7 @@
         -MemberType ScriptMethod `
         -Name GetPreRelease `
         -Value {
-            param( $Name )
+            param( $Name, $Wanted )
             $resource = $this.APIs.resources | Where-Object {
                 $_."@type" -eq "PackageBaseAddress/3.0.0"
             }
@@ -53,7 +53,18 @@
             $versions = Invoke-WebRequest $versions
             $versions = (ConvertFrom-Json $versions).versions
 
-            $versions | Select-Object -last 1
+            If( $Wanted ){
+                $out = $versions | Where-Object {
+                    $_ -eq $Wanted
+                }
+                If( $out ){
+                    $out
+                } Else {
+                    $versions | Select-Object -last 1
+                }
+            } Else {
+                $versions | Select-Object -last 1
+            }
         }
 
     $Exported | Add-Member `

--- a/Import-Package/packaging.ps1
+++ b/Import-Package/packaging.ps1
@@ -36,6 +36,28 @@
 
     $Exported | Add-Member `
         -MemberType ScriptMethod `
+        -Name GetPreRelease `
+        -Value {
+            param( $Name )
+            $resource = $this.APIs.resources | Where-Object {
+                $_."@type" -eq "PackageBaseAddress/3.0.0"
+            }
+            $id = $resource."@id"
+
+            $versions = @(
+                $id,
+                $Name,
+                "/index.json"
+            ) -join ""
+
+            $versions = Invoke-WebRequest $versions
+            $versions = (ConvertFrom-Json $versions).versions
+
+            $versions | Select-Object -last 1
+        }
+
+    $Exported | Add-Member `
+        -MemberType ScriptMethod `
         -Name ReadNuspec `
         -Value {
             param(

--- a/Import-Package/src/Build-PackageData.ps1
+++ b/Import-Package/src/Build-PackageData.ps1
@@ -20,14 +20,14 @@ function Build-PackageData {
         "Unmanaged" = $false
     }
 
-    $Options = If( $Options.Count -gt 1 ){
+    $Options = If( @($Options).Count -gt 1 ){
         $temp_options = @{}
         $Options | ForEach-Object {
             $iter_options = $_
             $Defaults.Keys | ForEach-Object {
                 $temp_options[ $_ ] = If( $iter_options[ $_ ] ){
                     $iter_options[ $_ ] 
-                } Elseif( $Defaults[ $_ ] -ne "Undefined") {
+                } Elseif( $Defaults[ $_ ].ToString() -ne "Undefined") {
                     $Defaults[ $_ ]
                 }
             }
@@ -35,7 +35,16 @@ function Build-PackageData {
 
         $temp_options
     } Else {
-        $Options
+        $temp_options = @{}
+        $Defaults.Keys | ForEach-Object {
+            $temp_options[ $_ ] = If( $Options[ $_ ] ){
+                $Options[ $_ ] 
+            } Elseif( $Defaults[ $_ ].ToString() -ne "Undefined") {
+                $Defaults[ $_ ]
+            }
+        }
+
+        $temp_options
     }
 
     Resolve-CachedPackage -From $From -Options $Options -Bootstrapper $Bootstrapper

--- a/Import-Package/src/Build-PackageData.ps1
+++ b/Import-Package/src/Build-PackageData.ps1
@@ -17,6 +17,7 @@ function Build-PackageData {
         "CachePath" = "Undefined"
         "TempPath" = "Undefined"
         "Offline" = $false
+        "Stable" = $true
         "Unmanaged" = $false
     }
 

--- a/Import-Package/src/Build-PackageData.ps1
+++ b/Import-Package/src/Build-PackageData.ps1
@@ -14,6 +14,7 @@ function Build-PackageData {
         "Name" = "Undefined"
         "Version" = "Undefined"
         "Source" = "Undefined"
+        "CachePath" = "Undefined"
         "TempPath" = "Undefined"
         "Offline" = $false
         "Unmanaged" = $false

--- a/Import-Package/src/Build-PackageData.ps1
+++ b/Import-Package/src/Build-PackageData.ps1
@@ -84,7 +84,7 @@ function Build-PackageData {
         $versions_available = $nuspec_version -and $Out.Version
         $names_available = $nuspec_id -and $Out.Name
 
-        $version_mismatch = $nuspec_version -ne $Out.Version
+        $version_mismatch = -not( $nuspec_version -like "$($Out.Version)*" )
         $names_mismatch = $nuspec_id -ne $Out.Name
 
         If( $names_available -and $versions_available ){

--- a/Import-Package/src/ConvertTo-SemVerObject.ps1
+++ b/Import-Package/src/ConvertTo-SemVerObject.ps1
@@ -1,0 +1,84 @@
+# Custom function to convert SemVer string to a comparable object
+# Using this over Automation.SemanticVersion, since Automation.SemanticVersion only works in pwsh 7.2+
+function ConvertTo-SemVerObject( [string]$semVerString ) {
+
+    $semVerParts = $semVerString -split '[-\+]'
+    If( $semVerParts.Count -gt 2 ){
+        $semVerParts = @(
+            $semVerParts[0],
+            (($semVerParts | Select-Object -Skip 1) -join "-")
+        )
+    }
+    $versionParts = $semVerParts[0] -split '\.'
+
+    $versionParts = $versionParts | ForEach-Object {
+        [int]$_
+    }
+
+    # Convert main version parts to integers
+    $major = $versionParts[0]
+    $minor = $versionParts[1]
+    $patch = $versionParts[2]
+    $legacyPrerelease = If( $versionParts.Count -gt 3 ){
+        $versionParts[3..($versionParts.Length-1)]
+    }
+
+    $preRelease = $null
+    if ($semVerParts.Length -gt 1) {
+        $preRelease = $semVerParts[1]
+    }
+
+    # Create a custom object
+    New-Object PSObject -Property @{
+        Major = $major
+        Minor = $minor
+        Patch = $patch
+        LegacyPrerelease = $legacyPrerelease
+        PreRelease = $preRelease
+        Original = $semVerString
+    }
+    
+}
+    
+# Custom comparison function for SemVer
+function Compare-SemVerObject($x, $y) {
+    if ($x.Major -ne $y.Major) {
+        return $x.Major - $y.Major
+    }
+    if ($x.Minor -ne $y.Minor) {
+        return $x.Minor - $y.Minor
+    }
+    if ($x.Patch -ne $y.Patch) {
+        return $x.Patch - $y.Patch
+    }
+    if ($x.LegacyPrerelease -and $y.LegacyPrerelease){
+        $max_length = [Math]::Max(
+            $x.LegacyPrerelease.Count,
+            $y.LegacyPrerelease.Count
+        )
+        for ($i = 0; $i -lt $max_length; $i++) {
+            $xlp = $x.LegacyPrerelease[ $i ]
+            $ylp = $y.LegacyPrerelease[ $i ]
+            If( $null -eq $xlp ){
+                return 1
+            }
+            If( $null -eq $ylp ){
+                return -1
+            }
+            If( $xlp -ne $ylp ){
+                return $xlp - $ylp
+            }
+        }
+    }
+    # Handle pre-release comparison
+    if ($x.PreRelease -and $y.PreRelease) {
+        return [string]::Compare($x.PreRelease, $y.PreRelease)
+    }
+    if ($x.PreRelease) {
+        return -1
+    }
+    if ($y.PreRelease) {
+        return 1
+    }
+    return 0
+}

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -259,7 +259,12 @@ function Resolve-CachedPackage {
             } Elseif( -not( $no_local ) ){
                 $Options.Version = $versions[ $versions.best.local ].local
 
-                $pm_package.Source
+                If( $versions.best.local -eq "cached" ){
+                    $package_name = "$( $Options.Name ).$( $versions.cached.local )"
+                    Join-Path $Options.CachePath "$package_name" "$package_name.nupkg"
+                } Else {
+                    $pm_package.Source
+                }
             } Else {
                 throw "[Import-Package:Preparation] Could not retrieve any packages for $( $Options.Name )"
             }

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -63,7 +63,7 @@ function Resolve-CachedPackage {
                 # If Options.Stable was false or an upstream stable version could not be found, try for a prerelease version
                 If( [string]::IsNullOrWhiteSpace( "$( $versions.pm.upstream )" ) ){
                     $versions.pm.upstream = Try {
-                        $Bootstrapper.GetPreRelease( $Options.Name )
+                        $Bootstrapper.GetPreRelease( $Options.Name, $versions.wanted )
                     } Catch {}
 
                     # If a prerelease was selected ensure $Options.Stable gets forced to false
@@ -264,7 +264,7 @@ function Resolve-CachedPackage {
                             $Options.Version, "/",
                             $package_name, ".nupkg"
                         ) -join ""
-                        
+
                         If(@(
                             $PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent,
                             ($VerbosePreference -ne 'SilentlyContinue')

--- a/Test.ps1
+++ b/Test.ps1
@@ -61,6 +61,11 @@ If( $ImportPackage ){
     Write-Host "[Import-Package:Testing] Testing the Unmanaged Parameterset with a complex package is complete. Continue Testing?"
     pause;
 
+    [Microsoft.ClearScript.V8.V8ScriptEngine]
+    [Avalonia.Application]
+    [Newtonsoft.Json.JsonConverter]
+    [NLua.Lua]
+
     Write-Host
     Write-Host "System Runtime ID:" (Get-Runtime)
 }

--- a/Test.ps1
+++ b/Test.ps1
@@ -61,10 +61,14 @@ If( $ImportPackage ){
     Write-Host "[Import-Package:Testing] Testing the Unmanaged Parameterset with a complex package is complete. Continue Testing?"
     pause;
 
+    Import-Package IronRuby.Libraries
+    Write-Host "[Import-Package:Testing] Testing the Semver2 packages (and the package cache) is complete. Continue Testing?"
+
     [Microsoft.ClearScript.V8.V8ScriptEngine]
     [Avalonia.Application]
     [Newtonsoft.Json.JsonConverter]
     [NLua.Lua]
+    [IronRuby.Ruby]
 
     Write-Host
     Write-Host "System Runtime ID:" (Get-Runtime)


### PR DESCRIPTION
PackageManagement doesn't support SemVer2, so a previous workaround for importing SemVer2 packages was to import them via -Path

However, in previous versions this had significantly contributed to file bloat by overusing the TempPath path.

The prior update attempted to partially tackle this problem. This update will complete the solution.