### PR TITLE
Patch (Minor): 0.5.4 - Improve TempPath Performance

### DIFF
--- a/Import-Package/Import-Package.psd1
+++ b/Import-Package/Import-Package.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Import-Package.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.5.3'
+ModuleVersion = '0.5.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Import-Package/Import-Package.psd1
+++ b/Import-Package/Import-Package.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Import-Package.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.5.2'
+ModuleVersion = '0.5.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -119,6 +119,9 @@ function Get-Runtime {
     .Parameter Offline
         Skip downloading the package from the package provider.
     
+    .Parameter CachePath
+        The directory to place and load packages not provided by PackageManagement. These can be SemVer2 packages or packages provided with -Path
+    
     .Parameter TempPath
         The directory to place and load native dlls from. Defaults to the current directory.
 

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -210,7 +210,8 @@ function Import-Package {
     
                 $mutexes."$id" = New-Object System.Threading.Mutex($true, "Global\ImportPackage-$id") # Lock the directory from automatic removal
     
-                New-Item -ItemType Directory -Path (Join-Path $parent $id) -Force
+                Join-Path $parent $id
+
                 # Resolve-Path "."
             }
             $true
@@ -497,7 +498,7 @@ function Import-Package {
             Write-Warning "[Import-Package:Loading] $($PackageData.Name) is not needed for $( $bootstrapper.Runtime )`:$($TargetFramework.GetShortFolderName())"
         }
 
-        If( $temp_path_generated ){
+        If( $temp_path_generated -and (Test-Path $TempPath) ){
             If( Test-Path (Join-Path $TempPath "*") ){
                 Write-Verbose "[Import-Package:Loading] Temp files: $TempPath"
             } Else {

--- a/Import-Package/README.md
+++ b/Import-Package/README.md
@@ -46,7 +46,10 @@ Import-Package `
 - TargetFramework:
   - The target framework of the package to import.
   - Default: TFM of the current PowerShell session.
-- TempPath
+
+- CachePath:
+  - The directory to place and load packages not provided by PackageManagement. These can be SemVer2 packages or packages provided with -Path
+- TempPath:
   - The directory to place and load native dlls from. Defaults to the current directory.
 
 

--- a/Import-Package/packaging.ps1
+++ b/Import-Package/packaging.ps1
@@ -215,6 +215,9 @@ public static extern IntPtr dlopen(string path, int flags);
                             {
                                 param( $Path, $CopyTo )
                                 If( $CopyTo ){
+                                    If( -not (Test-Path $CopyTo -PathType Container) ){
+                                        New-Item -ItemType Directory -Path $CopyTo -Force
+                                    }
                                     Write-Verbose "Loading native dll from path '$CopyTo' (copied from '$Path')."
                                     Copy-Item $Path $CopyTo -Force -ErrorAction SilentlyContinue | Out-Null
                                     $Path = "$CopyTo\$($Path | Split-Path -Leaf)"

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -282,7 +282,7 @@ function Resolve-CachedPackage {
                             $PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent,
                             ($VerbosePreference -ne 'SilentlyContinue')
                         ) -contains $true ){
-                            Write-Verbose "[Import-Package:Preparation] Installed $( $Options.Name ) $( $Options.Version ) from:"
+                            Write-Verbose "[Import-Package:Preparation] Installing $( $Options.Name ) $( $Options.Version ) from:"
                             Write-Host "-" $url -ForegroundColor Cyan
                             Write-Host
                         }


### PR DESCRIPTION
Improve TempPath performance by delegating the New-Item call to $bootstrapper.LoadNative

(WIP) Since this moves LoadNative is now in charge of the temppath, garbage collection may not be necessary if we convert TempPath to a secondary cache path.