### PR TITLE
Deprecation: 0.6.0 - Deprecate and replace TempPath with NativePath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 publish.ps1
 *.dll
 Import-Package/Packages
-Import-Package/Temp
 Import-Package/Natives

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ publish.ps1
 *.dll
 Import-Package/Packages
 Import-Package/Temp
+Import-Package/Natives

--- a/Import-Package/Import-Package.psd1
+++ b/Import-Package/Import-Package.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Import-Package.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.5.4'
+ModuleVersion = '0.6.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -398,7 +398,11 @@ function Import-Package {
             }
         }
 
-        $loaded[ $PackageData.Name ] = @(
+        If( -not $loaded[ $PackageData.Name ] ){
+            $loaded[ $PackageData.Name ] = @{}
+        }
+        $loaded[ $PackageData.Name ][ $PackageData.Version ] = @(
+            $PackageData.FullName,
             $TargetFramework.GetShortFolderName(),
             $target_rid_framework.GetShortFolderName()
         )

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -184,40 +184,7 @@ function Import-Package {
 
     Process {
 
-        $temp_path_generated = If( [string]::IsNullOrWhiteSpace( $TempPath ) ){
-            $TempPath = & {
-                $parent = & {
-                    Join-Path ($CachePath | Split-Path -Parent) "Temp"
-                }
-                [string] $uuid = [System.Guid]::NewGuid()
-    
-                # Cut dirname in half by compressing the UUID from base16 (hexadecimal) to base36 (alphanumeric)
-                $id = & {
-                    $bigint = [uint128]::Parse( $uuid.ToString().Replace("-",""), 'AllowHexSpecifier')
-                    $compressed = ""
-                    
-                    # Make hex-string more compressed by encoding it in base36 (alphanumeric)
-                    $chars = "0123456789abcdefghijklmnopqrstuvwxyz"
-                    While( $bigint -gt 0 ){
-                        $remainder = $bigint % 36
-                        $compressed = $chars[$remainder] + $compressed
-                        $bigint = $bigint/36
-                    }
-                    Write-Verbose "[Import-Package:Preparation] UUID $uuid (base16) converted to $compressed (base$( $chars.Length ))"
-    
-                    $compressed
-                }
-    
-                $mutexes."$id" = New-Object System.Threading.Mutex($true, "Global\ImportPackage-$id") # Lock the directory from automatic removal
-    
-                Join-Path $parent $id
-
-                # Resolve-Path "."
-            }
-            $true
-        } Else {
-            $false
-        }
+        $temp_path_generated = $false
 
         $PackageData = Switch( $PSCmdlet.ParameterSetName ){
             "Managed-Object" {
@@ -478,9 +445,9 @@ function Import-Package {
                         If( $bootstrapper.TestNative( $_.ToString() ) ){
                             Write-Verbose "[Import-Package:Loading] $_ is a native dll for $($PackageData.Name)"
                             Write-Verbose "- Moving to '$TempPath'"
-                            $bootstrapper.LoadNative( $_.ToString(), $TempPath ) | ForEach-Object { Write-Verbose "[Import-Package:Loading] Dll retunrned leaky handle $_"}   
+                            $bootstrapper.LoadNative( $_.ToString(), $TempPath ) | ForEach-Object { Write-Verbose "[Import-Package:Loading] $_ returned leaky handle $_"}   
                         } Else {
-                            Write-Verbose "[Import-Package:Loading] $_ is not native, but is a OS-specific dll for $($PackageData.Name)"
+                            Write-Verbose "[Import-Package:Loading] $_ is not native. It is, however, a OS-specific dll for $($PackageData.Name)"
                             Import-Module $_
                         }
                     } Catch {

--- a/Import-Package/Import-Package.psm1
+++ b/Import-Package/Import-Package.psm1
@@ -4,7 +4,6 @@ $bootstrapper = & (Resolve-Path "$PSScriptRoot\packaging.ps1")
 $loaded = @{
     "NuGet.Frameworks" = "netstandard2.0"
 }
-$mutexes = @{}
 
 New-Item (Join-Path $PSScriptRoot "Packages") -Force -ItemType Directory
 New-Item (Join-Path $PSScriptRoot "Temp") -Force -ItemType Directory

--- a/Import-Package/README.md
+++ b/Import-Package/README.md
@@ -49,7 +49,7 @@ Import-Package `
 
 - CachePath:
   - The directory to place and load packages not provided by PackageManagement. These can be SemVer2 packages or packages provided with -Path
-- TempPath:
+- NativePath:
   - The directory to place and load native dlls from. Defaults to the current directory.
 
 

--- a/Import-Package/packaging.ps1
+++ b/Import-Package/packaging.ps1
@@ -220,10 +220,10 @@ public static extern IntPtr dlopen(string path, int flags);
                                     }
                                     Write-Verbose "Loading native dll from path '$CopyTo' (copying from '$Path')."
                                     $end_path = "$CopyTo\$($Path | Split-Path -Leaf)"
-                                    If( -not (Test-Path $end_path -PathType Leaf) ){
-                                        Copy-Item $Path $CopyTo -Force -ErrorAction SilentlyContinue | Out-Null
-                                    } Else {
+                                    If( Test-Path $end_path -PathType Leaf ){
                                         Write-Verbose "$CopyTo is already present and loaded. Native dll not copied - This could cause version conflicts"
+                                    } Else {
+                                        Copy-Item $Path $CopyTo -Force -ErrorAction SilentlyContinue | Out-Null
                                     }
                                     $Path = $end_path
                                 } Else {

--- a/Import-Package/packaging.ps1
+++ b/Import-Package/packaging.ps1
@@ -218,9 +218,14 @@ public static extern IntPtr dlopen(string path, int flags);
                                     If( -not (Test-Path $CopyTo -PathType Container) ){
                                         New-Item -ItemType Directory -Path $CopyTo -Force
                                     }
-                                    Write-Verbose "Loading native dll from path '$CopyTo' (copied from '$Path')."
-                                    Copy-Item $Path $CopyTo -Force -ErrorAction SilentlyContinue | Out-Null
-                                    $Path = "$CopyTo\$($Path | Split-Path -Leaf)"
+                                    Write-Verbose "Loading native dll from path '$CopyTo' (copying from '$Path')."
+                                    $end_path = "$CopyTo\$($Path | Split-Path -Leaf)"
+                                    If( -not (Test-Path $end_path -PathType Leaf) ){
+                                        Copy-Item $Path $CopyTo -Force -ErrorAction SilentlyContinue | Out-Null
+                                    } Else {
+                                        Write-Verbose "$CopyTo is already present and loaded. Native dll not copied - This could cause version conflicts"
+                                    }
+                                    $Path = $end_path
                                 } Else {
                                     Write-Verbose "Loading native dll from path '$Path'."
                                 }

--- a/Import-Package/src/Build-PackageData.ps1
+++ b/Import-Package/src/Build-PackageData.ps1
@@ -12,6 +12,7 @@ function Build-PackageData {
     
     $Defaults = @{
         "Name" = "Undefined"
+        "Fullname" = "Undefined"
         "Version" = "Undefined"
         "Source" = "Undefined"
         "CachePath" = "Undefined"

--- a/Import-Package/src/Build-PackageData.ps1
+++ b/Import-Package/src/Build-PackageData.ps1
@@ -15,7 +15,7 @@ function Build-PackageData {
         "Version" = "Undefined"
         "Source" = "Undefined"
         "CachePath" = "Undefined"
-        "TempPath" = "Undefined"
+        "NativePath" = "Undefined"
         "Offline" = $false
         "Stable" = $true
         "Unmanaged" = $false
@@ -192,7 +192,7 @@ function Build-PackageData {
 
     <#
         Output Object Keys:
-        - TempPath
+        - NativePath
         - Unmanaged
         - Offline
 

--- a/Import-Package/src/Build-PackageData.ps1
+++ b/Import-Package/src/Build-PackageData.ps1
@@ -19,6 +19,7 @@ function Build-PackageData {
         "Offline" = $false
         "Stable" = $true
         "Unmanaged" = $false
+        "Installed" = $false
     }
 
     $Options = If( @($Options).Count -gt 1 ){

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -354,26 +354,7 @@ function Resolve-CachedPackage {
             $parent = & {
                 Join-Path ($CachePath | Split-Path -Parent) "Natives"
             }
-            [string] $uuid = [System.Guid]::NewGuid()
-
-            # Cut dirname in half by compressing the UUID from base16 (hexadecimal) to base36 (alphanumeric)
-            $id = & {
-                $bigint = [uint128]::Parse( $uuid.ToString().Replace("-",""), 'AllowHexSpecifier')
-                $compressed = ""
-                
-                # Make hex-string more compressed by encoding it in base36 (alphanumeric)
-                $chars = "0123456789abcdefghijklmnopqrstuvwxyz"
-                While( $bigint -gt 0 ){
-                    $remainder = $bigint % 36
-                    $compressed = $chars[$remainder] + $compressed
-                    $bigint = $bigint/36
-                }
-                Write-Verbose "[Import-Package:Preparation] UUID $uuid (base16) converted to $compressed (base$( $chars.Length ))"
-
-                $compressed
-            }
-
-            Join-Path $parent $id
+            Join-Path $parent $Options.FullName
         }
     } Else {
         $Options.NativePath

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -336,6 +336,8 @@ function Resolve-CachedPackage {
         }
     }
 
+    $Options.Fullname = $Options.Source | Split-Path -LeafBase
+
     If( [string]::IsNullOrWhiteSpace( $Options.NativePath ) ){
         $Options.NativePath = & {
             <#

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -10,10 +10,16 @@ function Resolve-CachedPackage {
         $Options
     )
 
-    If( [string]::IsNullOrWhiteSpace( $Options.TempPath ) ){
-        $Options.TempPath = & {
+    If( [string]::IsNullOrWhiteSpace( $Options.NativePath ) ){
+        $Options.NativePath = & {
+            <#
+                (WIP - #49) I'm thinking that this is where we should check to see if the currently processed dependency already has a Natives Folder
+                - Then instead of generating a new NativePath, we copy the Natives from this pre-existing folder to the parent.
+                - Obviously don't do this in this If block
+                - This If block should only run for the base of the dependency tree, if the user did not specify their own nativepath
+            #>
             $parent = & {
-                Join-Path ($CachePath | Split-Path -Parent) "Temp"
+                Join-Path ($CachePath | Split-Path -Parent) "Natives"
             }
             [string] $uuid = [System.Guid]::NewGuid()
 

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -10,6 +10,41 @@ function Resolve-CachedPackage {
         $Options
     )
 
+    If( [string]::IsNullOrWhiteSpace( $Options.TempPath ) ){
+        $Options.TempPath = & {
+            $parent = & {
+                Join-Path ($CachePath | Split-Path -Parent) "Temp"
+            }
+            [string] $uuid = [System.Guid]::NewGuid()
+
+            # Cut dirname in half by compressing the UUID from base16 (hexadecimal) to base36 (alphanumeric)
+            $id = & {
+                $bigint = [uint128]::Parse( $uuid.ToString().Replace("-",""), 'AllowHexSpecifier')
+                $compressed = ""
+                
+                # Make hex-string more compressed by encoding it in base36 (alphanumeric)
+                $chars = "0123456789abcdefghijklmnopqrstuvwxyz"
+                While( $bigint -gt 0 ){
+                    $remainder = $bigint % 36
+                    $compressed = $chars[$remainder] + $compressed
+                    $bigint = $bigint/36
+                }
+                Write-Verbose "[Import-Package:Preparation] UUID $uuid (base16) converted to $compressed (base$( $chars.Length ))"
+
+                $compressed
+            }
+
+            $mutexes."$id" = New-Object System.Threading.Mutex($true, "Global\ImportPackage-$id") # Lock the directory from automatic removal
+
+            Join-Path $parent $id
+
+            # Resolve-Path "."
+        }
+        $true
+    } Else {
+        $false
+    }
+
     switch( $From ){
         "Object" {}
         "Install" {

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -231,7 +231,7 @@ function Resolve-CachedPackage {
 
             $Options.Source = If( $install_condition ){
                 If( $Options.Stable ){
-                    Write-Verbose "[Import-Package:Preparation] Installing $( $Options.Name ) $( $versions[ $versions.best.upstream ].upstream )"
+                    Write-Verbose "[Import-Package:Preparation] Installing $( $Options.Name ) $( $versions[ $versions.best.upstream ].upstream ) via PackageManagement"
                     Try {
                         Install-Package $Options.Name `
                             -ProviderName NuGet `
@@ -253,6 +253,7 @@ function Resolve-CachedPackage {
                     If( $pm_package ){
                         $Options.Installed = $true
                         $Options.Version = $versions[ $versions.best.upstream ].upstream
+                        Write-Verbose "[Import-Package:Preparation] Source for $( $Options.Name ) $( $Options.Version ) set to PackageManagement cache"
 
                         $pm_package.Source
                     } Else {
@@ -260,6 +261,8 @@ function Resolve-CachedPackage {
                     }
                 } Else {
                     $Options.Version = $versions[ $versions.best.upstream ].upstream
+                    Write-Verbose "[Import-Package:Preparation] Source for $( $Options.Name ) $( $Options.Version ) set to Import-Package cache"
+
                     $package_name = "$( $Options.Name ).$( $Options.Version )"
                     
                     $output_path = Join-Path $Options.CachePath "$package_name" "$package_name.nupkg"
@@ -301,9 +304,11 @@ function Resolve-CachedPackage {
                 $Options.Version = $versions[ $versions.best.local ].local
 
                 If( $versions.best.local -eq "cached" ){
+                    Write-Verbose "[Import-Package:Preparation] Source for $( $Options.Name ) $( $Options.Version ) set to Import-Package cache"
                     $package_name = "$( $Options.Name ).$( $Options.Version )"
                     Join-Path $Options.CachePath "$package_name" "$package_name.nupkg"
                 } Else {
+                    Write-Verbose "[Import-Package:Preparation] Source for $( $Options.Name ) $( $Options.Version ) set to PackageManagement cache"
                     $pm_package.Source
                 }
             } Else {

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -251,6 +251,7 @@ function Resolve-CachedPackage {
                     # Error check it and return it:
                     $pm_package = Get-Package $Options.Name -RequiredVersion $versions[ $versions.best.upstream ].upstream -ProviderName NuGet -ErrorAction Stop
                     If( $pm_package ){
+                        $Options.Installed = $true
                         $Options.Version = $versions[ $versions.best.upstream ].upstream
 
                         $pm_package.Source
@@ -290,6 +291,8 @@ function Resolve-CachedPackage {
                         New-Item (Split-Path $output_path) -Force -ItemType Directory | Out-Null
                         Invoke-WebRequest -Uri $url -OutFile $output_path -ErrorAction Stop | Out-Null
                         [System.IO.Compression.ZipFile]::ExtractToDirectory( $output_path, (Split-Path $output_path), $true ) | Out-Null
+
+                        $Options.Installed = $true
 
                         $output_path
                     }

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -372,8 +372,5 @@ function Resolve-CachedPackage {
 
             # Resolve-Path "."
         }
-        $true
-    } Else {
-        $false
     }
 }

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -369,8 +369,6 @@ function Resolve-CachedPackage {
             }
 
             Join-Path $parent $id
-
-            # Resolve-Path "."
         }
     }
 }

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -34,8 +34,6 @@ function Resolve-CachedPackage {
                 $compressed
             }
 
-            $mutexes."$id" = New-Object System.Threading.Mutex($true, "Global\ImportPackage-$id") # Lock the directory from automatic removal
-
             Join-Path $parent $id
 
             # Resolve-Path "."

--- a/Import-Package/src/Resolve-CachedPackage.ps1
+++ b/Import-Package/src/Resolve-CachedPackage.ps1
@@ -386,6 +386,15 @@ function Resolve-CachedPackage {
         If( Test-Path $this_natives_path ){
             Write-Verbose "[Import-Package:Preparation] Native files for $( $Options.Name ) $( $Options.Version ) will be copied from cache now:"
             Write-Verbose "- Folder: $this_natives_path"
+            Resolve-Path (Join-Path $this_natives_path "*") -ErrorAction SilentlyContinue | ForEach-Object {
+                $native = $_
+                $native_name = $_ | Split-Path -Leaf
+                If( Test-Path (Join-Path $base_natives_path $native_name) ){
+                    Write-Verbose "$native_name is already present and loaded. Native dll not copied - This could cause version conflicts"
+                } Else {
+                    Copy-Item $native $base_natives_path -Force -ErrorAction SilentlyContinue | Out-Null
+                }
+            }
         } Else {
             Write-Verbose "[Import-Package:Preparation] Any native files for $( $Options.Name ) $( $Options.Version ) will be copied from source at load time:"
             Write-Verbose "- Folder: $( $Options.Source )"

--- a/Test.ps1
+++ b/Test.ps1
@@ -1,6 +1,7 @@
 param(
-    [bool] $ImportPackage = $true,
-    [bool] $NewDispatchThread = $true,
+    [switch] $ImportPackage,
+    [Alias("NewThreadController")]
+    [switch] $NewDispatchThread,
     [string] $Root = (& {
             If( $PSScriptRoot ){
             $PSScriptRoot
@@ -9,6 +10,11 @@ param(
         }
     })
 )
+
+If( -not $ImportPackage -and -not $NewDispatchThread ){
+    $ImportPackage = $true
+    $NewDispatchThread = $true
+}
 
 $global:__testing = $true
 


### PR DESCRIPTION
Improves Build-PackageData, Resolve-CachedPackage, and $bootstrapper.LoadNative() (#49)
- caches native files, which _significantly_ improves load times.
- adds a FullName and Installed field to the output of Build-PackageData

Improves $loaded behavior (#50)